### PR TITLE
Fixed navigate function doesnt work before whole page is rendered

### DIFF
--- a/src/hooks/useEnsureSession.js
+++ b/src/hooks/useEnsureSession.js
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import useSession from "./useSession";
+import { paths } from "../paths";
+
+/**
+ * Hook for ensuring that the user is authenticated before rendering the component.
+ * Will redirect the user to the login page if they are not authenticated.
+ *
+ * @returns {void}
+ */
+export const useEnsureSession = () => {
+	const navigate = useNavigate();
+	const { isAuthenticated } = useSession();
+
+	useEffect(() => {
+		if (!isAuthenticated) {
+			navigate(paths.login);
+		}
+	}, [isAuthenticated, navigate]);
+};
+
+export default useEnsureSession;

--- a/src/pages/MainApp.js
+++ b/src/pages/MainApp.js
@@ -1,20 +1,12 @@
 import { Box } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2'; // Grid2 import
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import CutoutEyes from "../components/CutoutEyes";
 import Guestbook from "../components/Guestbook";
 import VisitorCounter from "../components/VisitorCounter";
-import useSession from '../hooks/useSession';
-import { paths } from '../paths';
+import useEnsureSession from '../hooks/useEnsureSession';
 
 export default function MainApp() {
-    const navigate = useNavigate();
-    const { isAuthenticated } = useSession();
-
-    if (!isAuthenticated) {
-        navigate(paths.login);
-    }
+    useEnsureSession();
 
     return (
         <Box sx={{flexGrow: 1, height: '100vh'}}>


### PR DESCRIPTION
I added another much simpler hook useEnsureSession.

Much cleaner implementation and less code/imports for using.

NB! The real reason why it works, is that previously isAuthenticated was actually false, but navigate function was null on the first render. In order for it to work it needed to be moved into useEffect to make sure page is first loaded.